### PR TITLE
Fixes for Blender 4.2+ and shader node fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # blender-import-glr
 Addon which adds glr import support to Blender, the free 3D modelling suite.
 
+My fork of this addon has fixes for Blender 4.3 support and materials created by the addon.
+
 ---
 
 ## About

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # blender-import-glr
 Addon which adds glr import support to Blender, the free 3D modelling suite.
 
-My fork of this addon has fixes for Blender 4.3 support and materials created by the addon.
+My fork of this addon has important fixes for Blender 4.3+ support and materials.
 
 ---
 

--- a/io_import_glr/shader.py
+++ b/io_import_glr/shader.py
@@ -114,12 +114,18 @@ class N64Shader:
         self.make_output()
 
         # Set material-level properties
-        mat.shadow_method = 'NONE'
-        mat.use_backface_culling = cull_backfacing
-        if self.use_alpha and show_alpha:
-            mat.blend_method = 'BLEND' if is_translucent else 'HASHED'
+        if bpy.app.version < (4, 2, 0):
+            mat.shadow_method = 'NONE'
+            if self.use_alpha and show_alpha:
+                mat.blend_method = 'BLEND' if is_translucent else 'HASHED'
+            else:
+                mat.blend_method = 'OPAQUE'
         else:
-            mat.blend_method = 'OPAQUE'
+            if self.use_alpha and show_alpha and is_translucent:
+                mat.surface_render_method = 'BLENDED'
+            else:
+                mat.surface_render_method = 'DITHERED'
+        mat.use_backface_culling = cull_backfacing
 
         # Custom props (useful for debugging)
         mat['N64 Texture 0'] = show_texture_info(tex0) if tex0['crc'] else ''

--- a/io_import_glr/shader.py
+++ b/io_import_glr/shader.py
@@ -226,6 +226,8 @@ class N64Shader:
 
     def make_output(self):
         x = self.get_next_x_position()
+        node_emission = self.nodes.new('ShaderNodeEmission')
+        node_emission.location = x, 160
 
         # If the shader needs alpha blending, combine the color and
         # alpha with a Transparent BSDF + Mix Shader.
@@ -235,18 +237,21 @@ class N64Shader:
 
             node_mix.location = x + 200, 300
             node_trans.location = x, 400
+            node_emission.location = x, 160
             x += 500
 
             self.connect('Combined Alpha', node_mix.inputs[0])
             self.connect(node_trans.outputs[0], node_mix.inputs[1])
-            self.connect('Combined Color', node_mix.inputs[2])
+            self.connect(node_emission.outputs[0], node_mix.inputs[2])
+            self.connect('Combined Color', node_emission.inputs[0])
 
         node_out = self.nodes.new('ShaderNodeOutputMaterial')
-        node_out.location = x, 160
+        node_out.location = x + 200, 260
         if self.use_alpha:
             self.connect(node_mix.outputs[0], node_out.inputs[0])
         else:
-            self.connect('Combined Color', node_out.inputs[0])
+            self.connect('Combined Color', node_emission.inputs[0])
+            self.connect(node_emission.outputs[0], node_out.inputs[0])
 
     def make_color_combiner(self, combiner, location):
         a, b, c, d = combiner


### PR DESCRIPTION
- These changes enable support for Blender 4.2 and higher. There is now a check for the user's current Blender version, and if 4.2+ is detected, the newer render method property (surface_render_method) is modified, instead of the legacy setting (blend_method).

- Fixed the previously incorrect shader setup which was missing an Emission shader. Previously, the automatically-created materials were lacking either an Emission or Principled shader, with the final color output from textures/vertex colors being wired directly into the final Material Output. This is an incorrect way to set up a material in Blender, violating standard practices. Textures and colors should never be hooked up directly to the material output, but instead should be hooked into a shader of some kind (like Emission), which is then itself connected to the Material Output. These code changes now add an Emission node automatically where it should be, complying with standard Blender material practices.

![image](https://github.com/user-attachments/assets/fcc22a5c-73c1-45f4-8954-8bb1ee243316)
